### PR TITLE
fix: Use File type instead of dynamic for setWallpaper parameter

### DIFF
--- a/lib/wallpaper_manager_plus.dart
+++ b/lib/wallpaper_manager_plus.dart
@@ -18,7 +18,7 @@ class WallpaperManagerPlus {
   /// It can be [homeScreen], [lockScreen], or [bothScreens].
   ///
   /// Throws an [ArgumentError] if [location] is invalid.
-  Future<String?> setWallpaper(dynamic imageFile, int location) async {
+  Future<String?> setWallpaper(File imageFile, int location) async {
     if (location != homeScreen &&
         location != lockScreen &&
         location != bothScreens) {


### PR DESCRIPTION
## Summary

- Changed `setWallpaper(dynamic imageFile, ...)` to `setWallpaper(File imageFile, ...)` in `WallpaperManagerPlus` class
- This matches the existing type signature in `WallpaperManagerPlusPlatform` interface

## Problem

The public API accepts `dynamic` but the platform interface expects `File`. When a caller accidentally passes a `String` path instead of a `File` object:

```dart
// This compiles but fails at runtime
await WallpaperManagerPlus().setWallpaper(tempFile.path, location);
```

Runtime error:
```
type 'String' is not a subtype of type 'File'
```

## Solution

Enforce type safety at compile time by using `File` in the public API, matching the platform interface. Now the above code would fail to compile with a clear type error.

## Breaking Change?

This is technically a breaking change for anyone passing non-File types, but such code was already broken at runtime. This just moves the error from runtime to compile time.